### PR TITLE
Update download.js

### DIFF
--- a/packages/nexrender-core/src/tasks/download.js
+++ b/packages/nexrender-core/src/tasks/download.js
@@ -59,7 +59,8 @@ const download = (job, settings, asset) => {
         case 'http':
         case 'https':
             /* TODO: maybe move to external package ?? */
-            return fetch(encodeURI(asset.src), asset.params || {})
+            const src = decodeURI(asset.src) === asset.src ? encodeURI(asset.src): asset.src
+            return fetch(src, asset.params || {})
                 .then(res => res.ok ? res : Promise.reject({reason: 'Initial error downloading file', meta: {url, error: res.error}}))
                 .then(res => {
                     const stream = fs.createWriteStream(asset.dest)


### PR DESCRIPTION
The asset src uri was being encoded twice if it is already encoded, I compared it first with decoded uri to make sure it is not already encoded and if it is we take it as is.